### PR TITLE
Feat: Handle WP scaled images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unrealesed
+* Implement conversion for WP scaled images.
+
 ## 1.2.1
 * Implement WebP image display on WP Media Library.
 * Prevent style bleeding from Options page.

--- a/inc/Services/MetaData.php
+++ b/inc/Services/MetaData.php
@@ -23,6 +23,7 @@ class MetaData extends Service implements Kernel {
 	 */
 	public function register(): void {
 		add_action( 'icfw_convert', [ $this, 'add_webp_meta_to_attachment' ], 10, 2 );
+		add_action( 'icfw_convert', [ $this, 'add_webp_for_scaled_image' ], 10, 2 );
 	}
 
 	/**
@@ -48,5 +49,38 @@ class MetaData extends Service implements Kernel {
 		if ( empty( get_post_meta( $attachment_id, 'icfw_img', true ) ) ) {
 			update_post_meta( $attachment_id, 'icfw_img', $webp );
 		}
+	}
+
+	/**
+	 * Add WebP meta for WP Scaled Images.
+	 *
+	 * This is responsible for creating WebP images for WP scaled
+	 * images (if any).
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string|\WP_Error $webp          WebP's relative path.
+	 * @param int              $attachment_id Image ID.
+	 *
+	 * @return void
+	 */
+	public function add_webp_for_scaled_image( $webp, $attachment_id ): void {
+		// Bail out early, if \WP_Error.
+		if ( is_wp_error( $webp ) ) {
+			return;
+		}
+
+		$image_url = (string) wp_get_attachment_url( $attachment_id );
+
+		if ( false === strpos( $image_url, '-scaled' ) ) {
+			return;
+		}
+
+		$this->source = [
+			'id'  => (int) $attachment_id,
+			'url' => $image_url,
+		];
+
+		$webp = $this->converter->convert();
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= Unrealesed =
+* Implement conversion for WP scaled images.
+
 = 1.2.1 =
 * Implement WebP image display on WP Media Library.
 * Prevent style bleeding from Options page.

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -99,6 +99,16 @@ class PluginTest extends TestCase {
 		\WP_Mock::expectActionAdded(
 			'icfw_convert',
 			[
+				Service::$services['ImageConverterWebP\Services\MetaData'],
+				'add_webp_for_scaled_image',
+			],
+			10,
+			2
+		);
+
+		\WP_Mock::expectActionAdded(
+			'icfw_convert',
+			[
 				Service::$services['ImageConverterWebP\Services\Logger'],
 				'add_logs_for_webp_conversions',
 			],

--- a/tests/Services/MetaDataTest.php
+++ b/tests/Services/MetaDataTest.php
@@ -11,6 +11,7 @@ use ImageConverterWebP\Services\MetaData;
  * @covers \ImageConverterWebP\Services\MetaData::__construct
  * @covers \ImageConverterWebP\Services\MetaData::register
  * @covers \ImageConverterWebP\Services\MetaData::add_webp_meta_to_attachment
+ * @covers \ImageConverterWebP\Services\MetaData::add_webp_for_scaled_image
  * @covers icfw_get_settings
  */
 class MetaDataTest extends TestCase {
@@ -28,6 +29,7 @@ class MetaDataTest extends TestCase {
 
 	public function test_register() {
 		\WP_Mock::expectActionAdded( 'icfw_convert', [ $this->metadata, 'add_webp_meta_to_attachment' ], 10, 2 );
+		\WP_Mock::expectActionAdded( 'icfw_convert', [ $this->metadata, 'add_webp_for_scaled_image' ], 10, 2 );
 
 		$this->metadata->register();
 


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/image-converter-webp/issues/12).

## Description / Background Context

We're noticing that the `show_webp_images_on_wp_media_modal` [callback](https://github.com/badasswp/image-converter-webp/blob/3f7d7c8eec36a320113e987b51ccf62b8d546d2e/inc/Services/Main.php#L215-L231) is not firing for WP scaled images. This is a specific edge-case related to WP __scaled images__.

<img width="958" alt="Screenshot 2025-01-14 at 17 10 03" src="https://github.com/user-attachments/assets/d0dc3003-daad-4aac-bb6a-c8f6e739a3f5" />

This PR implements a fix for this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly `composer install`
3. Upload an image with large dimensions for e.g. `2400 by 3600` so that WP scales it.
4. The image should now show the WebP version on the WP media modal window.

<img width="1120" alt="Screenshot 2025-02-14 at 11 45 13" src="https://github.com/user-attachments/assets/541271a3-1086-4129-9e3a-9e2c94521641" />