### PR TITLE
Chore: Add unit tests for WP scaled images

### DIFF
--- a/inc/Services/MetaData.php
+++ b/inc/Services/MetaData.php
@@ -23,7 +23,7 @@ class MetaData extends Service implements Kernel {
 	 */
 	public function register(): void {
 		add_action( 'icfw_convert', [ $this, 'add_webp_meta_to_attachment' ], 10, 2 );
-		add_action( 'icfw_convert', [ $this, 'add_webp_for_scaled_image' ], 10, 2 );
+		add_action( 'icfw_convert', [ $this, 'add_webp_for_scaled_images' ], 10, 2 );
 	}
 
 	/**
@@ -64,7 +64,7 @@ class MetaData extends Service implements Kernel {
 	 *
 	 * @return void
 	 */
-	public function add_webp_for_scaled_image( $webp, $attachment_id ): void {
+	public function add_webp_for_scaled_images( $webp, $attachment_id ): void {
 		// Bail out early, if \WP_Error.
 		if ( is_wp_error( $webp ) ) {
 			return;

--- a/tests/Interfaces/KernelTest.php
+++ b/tests/Interfaces/KernelTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ImageConverterWebP\Tests\Interfaces;
+
+use Mockery;
+use WP_Mock\Tools\TestCase;
+use ImageConverterWebP\Interfaces\Kernel;
+
+/**
+ * @covers \ImageConverterWebP\Interfaces\Kernel::register
+ */
+class KernelTest extends TestCase {
+	public Kernel $kernel;
+
+	public function setUp(): void {
+		\WP_Mock::setUp();
+
+		$this->kernel = $this->getMockForAbstractClass( Kernel::class );
+	}
+
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+	}
+
+	public function test_register() {
+		$this->kernel->expects( $this->once() )
+			->method( 'register' );
+
+		$this->kernel->register();
+
+		$this->assertConditionsMet();
+	}
+}

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -100,7 +100,7 @@ class PluginTest extends TestCase {
 			'icfw_convert',
 			[
 				Service::$services['ImageConverterWebP\Services\MetaData'],
-				'add_webp_for_scaled_image',
+				'add_webp_for_scaled_images',
 			],
 			10,
 			2

--- a/tests/Services/MetaDataTest.php
+++ b/tests/Services/MetaDataTest.php
@@ -4,6 +4,7 @@ namespace ImageConverterWebP\Tests\Services;
 
 use Mockery;
 use WP_Mock\Tools\TestCase;
+use ImageConverterWebP\Core\Converter;
 use ImageConverterWebP\Services\MetaData;
 
 /**
@@ -29,7 +30,7 @@ class MetaDataTest extends TestCase {
 
 	public function test_register() {
 		\WP_Mock::expectActionAdded( 'icfw_convert', [ $this->metadata, 'add_webp_meta_to_attachment' ], 10, 2 );
-		\WP_Mock::expectActionAdded( 'icfw_convert', [ $this->metadata, 'add_webp_for_scaled_image' ], 10, 2 );
+		\WP_Mock::expectActionAdded( 'icfw_convert', [ $this->metadata, 'add_webp_for_scaled_images' ], 10, 2 );
 
 		$this->metadata->register();
 
@@ -76,6 +77,67 @@ class MetaDataTest extends TestCase {
 			->andReturn( null );
 
 		$this->metadata->add_webp_meta_to_attachment( $webp, 1 );
+
+		$this->assertConditionsMet();
+	}
+
+	public function test_add_webp_for_scaled_images_bails_out_if_is_wp_error() {
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		$this->metadata->add_webp_for_scaled_images( $wp_error, 1 );
+
+		$this->assertConditionsMet();
+	}
+
+	public function test_add_webp_for_scaled_images_bails_out_if_image_is_not_scaled() {
+		$webp = 'https://example.com/wp-content/uploads/2024/01/sample.webp';
+
+		\WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_get_attachment_url' )
+			->once()
+			->with( 1 )
+			->andReturn( 'https://example.com/wp-content/uploads/2024/01/sample.jpg' );
+
+		$this->metadata->add_webp_for_scaled_images( $webp, 1 );
+
+		$this->assertConditionsMet();
+	}
+
+	public function test_add_webp_for_scaled_images_passes() {
+		$webp = 'https://example.com/wp-content/uploads/2024/01/sample.webp';
+
+		\WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_get_attachment_url' )
+			->once()
+			->with( 1 )
+			->andReturn( 'https://example.com/wp-content/uploads/2024/01/sample-scaled.jpg' );
+
+		$this->metadata->converter = Mockery::mock( Converter::class )->makePartial();
+		$this->metadata->converter->shouldAllowMockingProtectedMethods();
+
+		$this->metadata->converter->shouldReceive( 'convert' );
+
+		$this->metadata->add_webp_for_scaled_images( $webp, 1 );
 
 		$this->assertConditionsMet();
 	}

--- a/tests/Services/MetaDataTest.php
+++ b/tests/Services/MetaDataTest.php
@@ -38,18 +38,21 @@ class MetaDataTest extends TestCase {
 	}
 
 	public function test_add_webp_meta_to_attachment_bails_out_if_is_wp_error() {
-		$webp = 'https://example.com/wp-content/uploads/2024/01/sample.webp';
+		$wp_error = Mockery::mock( \WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'is_wp_error' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
 
 		$options = [
 			'logs' => true,
 		];
 
-		\WP_Mock::userFunction( 'is_wp_error' )
-			->once()
-			->with( $webp )
-			->andReturn( true );
-
-		$this->metadata->add_webp_meta_to_attachment( $webp, 1 );
+		$this->metadata->add_webp_meta_to_attachment( $wp_error, 1 );
 
 		$this->assertConditionsMet();
 	}
@@ -62,9 +65,11 @@ class MetaDataTest extends TestCase {
 		];
 
 		\WP_Mock::userFunction( 'is_wp_error' )
-			->once()
-			->with( $webp )
-			->andReturn( false );
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg instanceof \WP_Error;
+				}
+			);
 
 		\WP_Mock::userFunction( 'get_post_meta' )
 			->once()

--- a/tests/Services/MetaDataTest.php
+++ b/tests/Services/MetaDataTest.php
@@ -12,7 +12,7 @@ use ImageConverterWebP\Services\MetaData;
  * @covers \ImageConverterWebP\Services\MetaData::__construct
  * @covers \ImageConverterWebP\Services\MetaData::register
  * @covers \ImageConverterWebP\Services\MetaData::add_webp_meta_to_attachment
- * @covers \ImageConverterWebP\Services\MetaData::add_webp_for_scaled_image
+ * @covers \ImageConverterWebP\Services\MetaData::add_webp_for_scaled_images
  * @covers icfw_get_settings
  */
 class MetaDataTest extends TestCase {


### PR DESCRIPTION
Test PR.

## Description / Background Context

This PR introduces unit tests for the newly added method: `add_webp_for_scaled_images`.

## Testing Instructions

1. Pull PR to local.
2. Run tests like so: `composer run test`.
3. All tests should pass successfully like so:

<img width="387" alt="Screenshot 2025-02-14 at 15 52 56" src="https://github.com/user-attachments/assets/71a559c2-fd04-4a51-9abf-c7e11ae980f9" />