### PR TITLE
Chore: Add WP local dev env

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,13 +1,16 @@
 .editorconfig
 .gitignore
 .github
+.wp-env.json
 CHANGELOG.md
+package.json
 phpcs.xml
 phpstan.neon
 phpunit.xml
 README.md
 assets
 tests
+bin
 vendor/rosell-dk/exec-with-fallback/.github
 vendor/rosell-dk/file-util/.github
 vendor/rosell-dk/image-mime-type-guesser/.github

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 ###############################
 composer.lock
 package-lock.json
+yarn.lock
 
 # Ignore Folders #
 ##################

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,15 @@
+{
+	"plugins": [
+		"."
+	],
+	"phpVersion": "8.2",
+	"port": 5447,
+	"testsPort": 5448,
+	"config": {
+		"WP_SITEURL": "http://icfw.localhost",
+		"WP_HOME": "http://icfw.localhost"
+	},
+	"lifecycleScripts": {
+		"afterStart": "./bin/setup.sh"
+	}
+}

--- a/README.md
+++ b/README.md
@@ -235,6 +235,6 @@ This should spin up a local WP env instance for you to work with at:
 http://icfw.localhost:5447
 ```
 
-You should now have a functioning local WP env to work with. To login to the `wp-admin` backend, please username as `admin` & password as `password`.
+You should now have a functioning local WP env to work with. To login to the `wp-admin` backend, please use `admin` for username & `password` for password.
 
 __Awesome!__ - Thanks for being interested in contributing your time and code to this project!

--- a/README.md
+++ b/README.md
@@ -211,11 +211,30 @@ public function delete_bmp_image( $webp, $attachment_id ): void {
 
 ---
 
-## Development
+## Contribute
 
-### Setup
+Contributions are __welcome__ and will be fully __credited__. To contribute, please fork this repo and raise a PR (Pull Request) against the `master` branch.
 
-- Clone the repository.
-- Make sure you have [Composer](https://getcomposer.org) and PHP `v7.4|v8.0` installed in your computer.
-- Run `composer install` to build PHP dependencies.
-- For local development, you can use [Docker](https://docs.docker.com/install/) or [Local by Flywheel](https://localwp.com/).
+### Pre-requisites
+
+You should have the following tools before proceeding to the next steps:
+
+- Composer
+- Yarn
+- Docker
+
+To enable you start development, please run:
+
+```bash
+yarn start
+```
+
+This should spin up a local WP env instance for you to work with at:
+
+```bash
+http://icfw.localhost:5447
+```
+
+You should now have a functioning local WP env to work with. To login to the `wp-admin` backend, please username as `admin` & password as `password`.
+
+__Awesome!__ - Thanks for being interested in contributing your time and code to this project!

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+wp-env run cli wp theme activate twentytwentythree
+wp-env run cli wp rewrite structure /%postname%
+wp-env run cli wp option update blogname "Image Converter for WebP"
+wp-env run cli wp option update blogdescription "Image Converter for WebP"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "image-converter-for-webp",
+	"version": "1.3.1",
+	"description": "Convert your WP images to WebP formats.",
+	"author": "badasswp",
+	"license": "GPL-2.0-or-later",
+	"homepage": "https://github.com/badasswp/image-converter-for-webp#readme",
+	"scripts": {
+		"start": "yarn boot && yarn wp-env start",
+		"stop": "yarn wp-env stop",
+		"boot": "composer install && yarn install",
+		"test": "npm-run-all --parallel test:*",
+		"test:php": "composer run test",
+		"lint:php": "composer run lint",
+		"lint:php:fix": "composer run lint:fix",
+		"ci": "yarn test:php && yarn lint:php",
+		"wp-env": "wp-env",
+		"bash": "wp-env run cli bash"
+	},
+	"devDependencies": {
+		"@wordpress/env": "^10.20.0"
+	},
+	"keywords": [
+		"wordpress",
+		"plugin",
+		"image",
+		"converter",
+		"webp",
+		"optimize",
+		"compress"
+	]
+}


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/image-converter-webp/issues/17).

## Description / Background Context

At the moment, contributors have to use their own methods of setting up this repo. We need to provide a consistent way for users to spin up this project's repo and contribute quickly perhaps using WP's `wp-env` so that users can now spin up their local instance by running:

```bash
yarn wp-env start
```

This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. The repo should now build and boot up the `wp-env` instance ready for the user.
4. User should be able to access the site at: `http://icfw.localhost:5447`