### PR TITLE
Chore: Translate Options label correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.2
+* Translate Options label correctly.
+* Tested up to WP 6.8.
+
 ## 1.3.1
 * Chore: Add WP local dev env.
 * Chore: Update README docs.

--- a/image-converter-webp.php
+++ b/image-converter-webp.php
@@ -3,7 +3,7 @@
  * Plugin Name: Image Converter for WebP
  * Plugin URI:  https://github.com/badasswp/image-converter-webp
  * Description: Convert your WordPress JPG/PNG images to WebP formats during runtime.
- * Version:     1.3.1
+ * Version:     1.3.2
  * Author:      badasswp
  * Author URI:  https://github.com/badasswp
  * License:     GPL v2 or later

--- a/inc/Admin/Options.php
+++ b/inc/Admin/Options.php
@@ -170,7 +170,7 @@ class Options {
 				],
 			],
 			'icfw_log_options'  => [
-				'heading'  => 'Log Options',
+				'heading'  => esc_html__( 'Log Options', 'image-converter-webp' ),
 				'controls' => [
 					'logs' => [
 						'control' => esc_attr( 'checkbox' ),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "image-converter-for-webp",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Convert your WP images to WebP formats.",
 	"author": "badasswp",
 	"license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,10 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.3.2 =
+* Translate Options label correctly.
+* Tested up to WP 6.8.
+
 = 1.3.1 =
 * Chore: Add WP local dev env.
 * Chore: Update README docs.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: badasswp
 Tags: webp, image, convert, jpeg, png.
 Requires at least: 4.0
 Tested up to: 6.7.2
-Stable tag: 1.3.1
+Stable tag: 1.3.2
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This PR resolves the issue related to missing translation for one of the options label.

## Description / Background Context

A while ago, it was reported that one of the Options label was missing translation. We need to sort this out. This PR fixes this missing translation.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. Change your WP translation to your language of choice (Danish, German, French, Italian, Russian, Croatian, Chinese).
4. Observe that the `Log Options` label is translated correctly.
5. Observe that there are no regressions introduced with this change.